### PR TITLE
Support rql-parser 2.x and like operator with minimal changes, thanks to @dontub.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": ">=5.5",
+    "php": ">=5.6",
     "xiag/rql-parser": "*",
     "xiag/rql-command": "*",
     "doctrine/orm": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
   ],
   "require": {
     "php": ">=5.5",
-    "xiag/rql-parser": "^1",
+    "xiag/rql-parser": "*",
+    "xiag/rql-command": "*",
     "doctrine/orm": "^2.5",
     "andreas-glaser/php-helpers": "dev-master",
     "doctrine/data-fixtures": "^1.1"

--- a/src/Helper/RQLParser.php
+++ b/src/Helper/RQLParser.php
@@ -3,12 +3,16 @@
 namespace AndreasGlaser\DoctrineRql\Helper;
 
 use Xiag\Rql\Parser as Xiag;
+use Xiag\Rql\Parser\NodeParser\Query\LogicalOperator as XiagLogicalOperator;
+use Xiag\Rql\Parser\NodeParser\Query\ComparisonOperator as XiagComparisonOperator;
 
 /**
  * Class RQLParser
  *
  * @package AndreasGlaser\DoctrineRql\Helper
  * @author  Andreas Glaser
+ * @author  Dominic Tubach <dominic.tubach@to.com>
+ * @author  Rodrigo de Aquino <rodrigo@totlab.com.br>
  */
 class RQLParser
 {
@@ -17,55 +21,67 @@ class RQLParser
      *
      * @return \Xiag\Rql\Parser\Parser
      * @author Andreas Glaser
+     * @author Dominic Tubach <dominic.tubach@to.com>
      */
     public static function createAll()
     {
-        return Xiag\Parser::createDefault();
+        return new Xiag\Parser(Xiag\Parser::createDefaultNodeParser());
     }
 
     /**
      * Creates WHERE/SORT/LIMIT parser.
      *
-     * @return Xiag\Parser
+     * @return \Xiag\Rql\Parser\Parser
      * @author Andreas Glaser
+     * @author Dominic Tubach <dominic.tubach@to.com>
      */
     public static function createFiltersOnly()
     {
-        $queryTokenParser = new Xiag\TokenParserGroup();
-        $queryTokenParser
-            ->addTokenParser(new Xiag\TokenParser\Query\GroupTokenParser($queryTokenParser))
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\LogicOperator\AndTokenParser($queryTokenParser))
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\LogicOperator\OrTokenParser($queryTokenParser))
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\LogicOperator\NotTokenParser($queryTokenParser))
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\ArrayOperator\InTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\ArrayOperator\OutTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\ScalarOperator\EqTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\ScalarOperator\NeTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\ScalarOperator\LtTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\ScalarOperator\GtTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\ScalarOperator\LeTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\ScalarOperator\GeTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Basic\ScalarOperator\LikeTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Fiql\ArrayOperator\InTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Fiql\ArrayOperator\OutTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Fiql\ScalarOperator\EqTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Fiql\ScalarOperator\NeTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Fiql\ScalarOperator\LtTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Fiql\ScalarOperator\GtTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Fiql\ScalarOperator\LeTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Fiql\ScalarOperator\GeTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\Query\Fiql\ScalarOperator\LikeTokenParser());
+        $scalarParser = (new Xiag\ValueParser\ScalarParser())
+            ->registerTypeCaster('string', new Xiag\TypeCaster\StringTypeCaster())
+            ->registerTypeCaster('integer', new Xiag\TypeCaster\IntegerTypeCaster())
+            ->registerTypeCaster('float', new Xiag\TypeCaster\FloatTypeCaster())
+            ->registerTypeCaster('boolean', new Xiag\TypeCaster\BooleanTypeCaster());
 
-        return (new Xiag\Parser(
-            (new Xiag\ExpressionParser())
-                ->registerTypeCaster('string', new Xiag\TypeCaster\StringTypeCaster())
-                ->registerTypeCaster('integer', new Xiag\TypeCaster\IntegerTypeCaster())
-                ->registerTypeCaster('float', new Xiag\TypeCaster\FloatTypeCaster())
-                ->registerTypeCaster('boolean', new Xiag\TypeCaster\BooleanTypeCaster())
-        ))
-            ->addTokenParser($queryTokenParser)
-            ->addTokenParser(new Xiag\TokenParser\SortTokenParser())
-            ->addTokenParser(new Xiag\TokenParser\LimitTokenParser());
+        $arrayParser = new Xiag\ValueParser\ArrayParser($scalarParser);
+        $globParser = new Xiag\ValueParser\GlobParser();
+        $fieldParser = new Xiag\ValueParser\FieldParser();
+        $integerParser = new Xiag\ValueParser\IntegerParser();
+
+        $queryNodeParser = new Xiag\NodeParser\QueryNodeParser();
+        $queryNodeParser
+            ->addNodeParser(new Xiag\NodeParser\Query\GroupNodeParser($queryNodeParser))
+
+            ->addNodeParser(new XiagLogicalOperator\AndNodeParser($queryNodeParser))
+            ->addNodeParser(new XiagLogicalOperator\OrNodeParser($queryNodeParser))
+            ->addNodeParser(new XiagLogicalOperator\NotNodeParser($queryNodeParser))
+
+            ->addNodeParser(new XiagComparisonOperator\Rql\InNodeParser($fieldParser, $arrayParser))
+            ->addNodeParser(new XiagComparisonOperator\Rql\OutNodeParser($fieldParser, $arrayParser))
+            ->addNodeParser(new XiagComparisonOperator\Rql\EqNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Rql\NeNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Rql\LtNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Rql\GtNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Rql\LeNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Rql\GeNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Rql\LikeNodeParser($fieldParser, $globParser))
+
+            ->addNodeParser(new XiagComparisonOperator\Fiql\InNodeParser($fieldParser, $arrayParser))
+            ->addNodeParser(new XiagComparisonOperator\Fiql\OutNodeParser($fieldParser, $arrayParser))
+            ->addNodeParser(new XiagComparisonOperator\Fiql\EqNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Fiql\NeNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Fiql\LtNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Fiql\GtNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Fiql\LeNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Fiql\GeNodeParser($fieldParser, $scalarParser))
+            ->addNodeParser(new XiagComparisonOperator\Fiql\LikeNodeParser($fieldParser, $globParser));
+
+        $parserChain = new Xiag\NodeParserChain();
+        $parserChain
+            ->addNodeParser($queryNodeParser)
+            ->addNodeParser(new Xiag\NodeParser\SortNodeParser($fieldParser))
+            ->addNodeParser(new Xiag\NodeParser\LimitNodeParser($integerParser));
+        return new Xiag\Parser($parserChain);
     }
 
     /**

--- a/src/Visitor/ORMVisitor.php
+++ b/src/Visitor/ORMVisitor.php
@@ -5,6 +5,7 @@ namespace AndreasGlaser\DoctrineRql\Visitor;
 use AndreasGlaser\Helpers\ArrayHelper;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
+use Xiag\Rql\Parser\Glob;
 use Xiag\Rql\Parser\Node;
 use Xiag\Rql\Parser\Node\AbstractQueryNode;
 use Xiag\Rql\Parser\Node\Query\AbstractArrayOperatorNode;
@@ -179,7 +180,14 @@ class ORMVisitor
         $parameterName = ':param_' . uniqid();
         $pathToField = $node->getField();
         $exp = $this->qb->expr()->$method($this->pathToAlias($pathToField), $parameterName);
-        $this->qb->setParameter($parameterName, $node->getValue());
+
+        $parameter = $node->getValue();
+        if ($parameter instanceof Glob)
+        {
+            $parameter = $parameter->toLike();
+        }
+
+        $this->qb->setParameter($parameterName, $parameter);
 
         return $exp;
     }
@@ -261,7 +269,8 @@ class ORMVisitor
      */
     protected function pathToAlias($path)
     {
-        if ($this->autoRootAlias) {
+        if ($this->autoRootAlias)
+        {
             $path = $this->autoRootAlias . '.' . $path;
         }
 


### PR DESCRIPTION
I merge changes from @dontub removing "ExpressionBuilder" it is working well on Symfony version 3.1.4.
